### PR TITLE
Increase task channel buffer size

### DIFF
--- a/master/main.go
+++ b/master/main.go
@@ -58,7 +58,7 @@ type Config struct {
 var metricsFilePath = "/home/ubuntu/metrics/metrics"
 var workers NodeCollection
 var storageNodes NodeCollection
-var taskChannel = make(chan task, 100)
+var taskChannel = make(chan task, 10000)
 
 var Sess *session.Session
 

--- a/worker/main.go
+++ b/worker/main.go
@@ -72,7 +72,7 @@ func main() {
 	register()
 	go checkMasterHealth()
 
-	taskChannel = make(chan task, 10)
+	taskChannel = make(chan task, 1000)
 	go ProcessGraphsWhenAvailable()
 	server := &http.Server{
 		Handler:      router,
@@ -204,7 +204,6 @@ func ProcessGraph(graph *graphs.Graph, parameters map[string]string) {
 	step := 0
 outerloop:
 	for true {
-		time.Sleep(10 * time.Millisecond)
 		for _, node := range graph.Nodes {
 			if node.Active {
 				instance.Step(node, step)


### PR DESCRIPTION
Requests timeden out omdat de channels gingen blocken bij lage maxworkers. 